### PR TITLE
Add library projects

### DIFF
--- a/Assets/UniRx/Scripts/Schedulers/Scheduler.cs
+++ b/Assets/UniRx/Scripts/Schedulers/Scheduler.cs
@@ -56,7 +56,11 @@ namespace UniRx
             {
                 get
                 {
+#if UniRxLibrary
+                    return timeBasedOperations ?? (timeBasedOperations = Scheduler.ThreadPool);
+#else
                     return timeBasedOperations ?? (timeBasedOperations = Scheduler.MainThread); // MainThread as default for TimeBased Operation
+#endif
                 }
                 set
                 {
@@ -75,15 +79,6 @@ namespace UniRx
                 {
                     asyncConversions = value;
                 }
-            }
-
-            public static void SetDefaultForUnity()
-            {
-                ConstantTimeOperations = Scheduler.Immediate;
-                TailRecursion = Scheduler.Immediate;
-                Iteration = Scheduler.CurrentThread;
-                TimeBasedOperations = Scheduler.MainThread;
-                AsyncConversions = Scheduler.ThreadPool;
             }
 
             public static void SetDotNetCompatible()

--- a/Assets/UniRx/Scripts/UnityEngineBridge/AsyncOperationExtensions.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/AsyncOperationExtensions.cs
@@ -2,6 +2,10 @@
 using System.Collections;
 using UnityEngine;
 
+#if !UniRxLibrary
+using ObservableUnity = UniRx.Observable;
+#endif
+
 namespace UniRx
 {
     public static partial class AsyncOperationExtensions
@@ -11,14 +15,14 @@ namespace UniRx
         /// </summary>
         public static IObservable<AsyncOperation> AsObservable(this AsyncOperation asyncOperation, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<AsyncOperation>((observer, cancellation) => AsObservableCore(asyncOperation, observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<AsyncOperation>((observer, cancellation) => AsObservableCore(asyncOperation, observer, progress, cancellation));
         }
 
         // T: where T : AsyncOperation is ambigious with IObservable<T>.AsObservable
         public static IObservable<T> AsAsyncOperationObservable<T>(this T asyncOperation, IProgress<float> progress = null)
             where T : AsyncOperation
         {
-            return Observable.FromCoroutine<T>((observer, cancellation) => AsObservableCore(asyncOperation, observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<T>((observer, cancellation) => AsObservableCore(asyncOperation, observer, progress, cancellation));
         }
 
         static IEnumerator AsObservableCore<T>(T asyncOperation, IObserver<T> observer, IProgress<float> reportProgress, CancellationToken cancel)

--- a/Assets/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/MainThreadScheduler.cs
@@ -7,8 +7,21 @@ using UnityEngine;
 
 namespace UniRx
 {
+#if UniRxLibrary
+    public static partial class SchedulerUnity
+    {
+#else
     public static partial class Scheduler
     {
+        public static void SetDefaultForUnity()
+        {
+            Scheduler.DefaultSchedulers.ConstantTimeOperations = Scheduler.Immediate;
+            Scheduler.DefaultSchedulers.TailRecursion = Scheduler.Immediate;
+            Scheduler.DefaultSchedulers.Iteration = Scheduler.CurrentThread;
+            Scheduler.DefaultSchedulers.TimeBasedOperations = MainThread;
+            Scheduler.DefaultSchedulers.AsyncConversions = Scheduler.ThreadPool;
+        }
+#endif
         static IScheduler mainThread;
 
         /// <summary>
@@ -125,7 +138,7 @@ namespace UniRx
             public IDisposable Schedule(TimeSpan dueTime, Action action)
             {
                 var d = new BooleanDisposable();
-                var time = Normalize(dueTime);
+                var time = Scheduler.Normalize(dueTime);
 
                 MainThreadDispatcher.SendStartCoroutine(DelayAction(time, () =>
                 {
@@ -220,7 +233,7 @@ namespace UniRx
             public IDisposable Schedule(TimeSpan dueTime, Action action)
             {
                 var d = new BooleanDisposable();
-                var time = Normalize(dueTime);
+                var time = Scheduler.Normalize(dueTime);
 
                 MainThreadDispatcher.SendStartCoroutine(DelayAction(time, () =>
                 {

--- a/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/ObservableWWW.cs
@@ -2,6 +2,10 @@ using System;
 using System.Collections;
 using UnityEngine;
 
+#if !UniRxLibrary
+using ObservableUnity = UniRx.Observable;
+#endif
+
 namespace UniRx
 {
 #if !(UNITY_METRO || UNITY_WP8) && (UNITY_4_4 || UNITY_4_3 || UNITY_4_2 || UNITY_4_1 || UNITY_4_0_1 || UNITY_4_0 || UNITY_3_5 || UNITY_3_4 || UNITY_3_3 || UNITY_3_2 || UNITY_3_1 || UNITY_3_0_0 || UNITY_3_0 || UNITY_2_6_1 || UNITY_2_6)
@@ -20,101 +24,101 @@ namespace UniRx
     {
         public static IObservable<string> Get(string url, Hash headers = null, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
         }
 
         public static IObservable<byte[]> GetAndGetBytes(string url, Hash headers = null, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
         }
         public static IObservable<WWW> GetWWW(string url, Hash headers = null, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, null, (headers ?? new Hash())), observer, progress, cancellation));
         }
 
         public static IObservable<string> Post(string url, byte[] postData, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, postData), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, postData), observer, progress, cancellation));
         }
 
         public static IObservable<string> Post(string url, byte[] postData, Hash headers, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, postData, headers), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, postData, headers), observer, progress, cancellation));
         }
 
         public static IObservable<string> Post(string url, WWWForm content, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, content), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, content), observer, progress, cancellation));
         }
 
         public static IObservable<string> Post(string url, WWWForm content, Hash headers, IProgress<float> progress = null)
         {
             var contentHeaders = content.headers;
-            return Observable.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<string>((observer, cancellation) => FetchText(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
         }
 
         public static IObservable<byte[]> PostAndGetBytes(string url, byte[] postData, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, postData), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, postData), observer, progress, cancellation));
         }
 
         public static IObservable<byte[]> PostAndGetBytes(string url, byte[] postData, Hash headers, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, postData, headers), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, postData, headers), observer, progress, cancellation));
         }
 
         public static IObservable<byte[]> PostAndGetBytes(string url, WWWForm content, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, content), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, content), observer, progress, cancellation));
         }
 
         public static IObservable<byte[]> PostAndGetBytes(string url, WWWForm content, Hash headers, IProgress<float> progress = null)
         {
             var contentHeaders = content.headers;
-            return Observable.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<byte[]>((observer, cancellation) => FetchBytes(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
         }
 
         public static IObservable<WWW> PostWWW(string url, byte[] postData, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, postData), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, postData), observer, progress, cancellation));
         }
 
         public static IObservable<WWW> PostWWW(string url, byte[] postData, Hash headers, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, postData, headers), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, postData, headers), observer, progress, cancellation));
         }
 
         public static IObservable<WWW> PostWWW(string url, WWWForm content, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, content), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, content), observer, progress, cancellation));
         }
 
         public static IObservable<WWW> PostWWW(string url, WWWForm content, Hash headers, IProgress<float> progress = null)
         {
             var contentHeaders = content.headers;
-            return Observable.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<WWW>((observer, cancellation) => Fetch(new WWW(url, content.data, MergeHash(contentHeaders, headers)), observer, progress, cancellation));
         }
 
         public static IObservable<AssetBundle> LoadFromCacheOrDownload(string url, int version, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, version), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, version), observer, progress, cancellation));
         }
 
         public static IObservable<AssetBundle> LoadFromCacheOrDownload(string url, int version, uint crc, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, version, crc), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, version, crc), observer, progress, cancellation));
         }
 
         // over Unity5 supports Hash128
 #if !(UNITY_4_6 || UNITY_4_5 || UNITY_4_4 || UNITY_4_3 || UNITY_4_2 || UNITY_4_1 || UNITY_4_0_1 || UNITY_4_0 || UNITY_3_5 || UNITY_3_4 || UNITY_3_3 || UNITY_3_2 || UNITY_3_1 || UNITY_3_0_0 || UNITY_3_0 || UNITY_2_6_1 || UNITY_2_6)
         public static IObservable<AssetBundle> LoadFromCacheOrDownload(string url, Hash128 hash128, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, hash128), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, hash128), observer, progress, cancellation));
         }
 
         public static IObservable<AssetBundle> LoadFromCacheOrDownload(string url, Hash128 hash128, uint crc, IProgress<float> progress = null)
         {
-            return Observable.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, hash128, crc), observer, progress, cancellation));
+            return ObservableUnity.FromCoroutine<AssetBundle>((observer, cancellation) => FetchAssetBundle(WWW.LoadFromCacheOrDownload(url, hash128, crc), observer, progress, cancellation));
         }
 #endif
 

--- a/Assets/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs
+++ b/Assets/UniRx/Scripts/UnityEngineBridge/ObserveExtensions.cs
@@ -1,6 +1,10 @@
 ﻿using System;
 using System.Collections;
 
+#if !UniRxLibrary
+using ObservableUnity = UniRx.Observable;
+#endif
+
 namespace UniRx
 {
     public static partial class ObserveExtensions
@@ -19,13 +23,13 @@ namespace UniRx
 
             if (isUnityObject)
             {
-                return Observable.FromCoroutine<TProperty>((observer, cancellationToken) => PublishUnityObjectValueChanged(unityObject, propertySelector, frameCountType, observer, cancellationToken));
+                return ObservableUnity.FromCoroutine<TProperty>((observer, cancellationToken) => PublishUnityObjectValueChanged(unityObject, propertySelector, frameCountType, observer, cancellationToken));
             }
             else
             {
                 var reference = new WeakReference(source);
                 source = null;
-                return Observable.FromCoroutine<TProperty>((observer, cancellationToken) => PublishPocoValueChanged(reference, propertySelector, frameCountType, observer, cancellationToken));
+                return ObservableUnity.FromCoroutine<TProperty>((observer, cancellationToken) => PublishPocoValueChanged(reference, propertySelector, frameCountType, observer, cancellationToken));
             }
         }
 

--- a/Dlls/UniRx.Library.Unity/Properties/AssemblyInfo.cs
+++ b/Dlls/UniRx.Library.Unity/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UniRx.Library.Unity")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UniRx.Library.Unity")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Dlls/UniRx.Library.Unity/UniRx.Library.Unity.csproj
+++ b/Dlls/UniRx.Library.Unity/UniRx.Library.Unity.csproj
@@ -1,0 +1,210 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UniRx.Unity</RootNamespace>
+    <AssemblyName>UniRx.Unity</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UniRxLibrary</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Library\UnityAssemblies\UnityEngine.dll</HintPath>
+    </Reference>
+    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\..\Library\UnityAssemblies\UnityEngine.UI.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\AsyncOperationExtensions.cs">
+      <Link>UnityEngineBridge\AsyncOperationExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\CancellationToken.cs">
+      <Link>UnityEngineBridge\CancellationToken.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Diagnostics\LogEntry.cs">
+      <Link>UnityEngineBridge\Diagnostics\LogEntry.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Diagnostics\LogEntryExtensions.cs">
+      <Link>UnityEngineBridge\Diagnostics\LogEntryExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Diagnostics\Logger.cs">
+      <Link>UnityEngineBridge\Diagnostics\Logger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Diagnostics\ObservableLogger.cs">
+      <Link>UnityEngineBridge\Diagnostics\ObservableLogger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Diagnostics\UnityDebugSink.cs">
+      <Link>UnityEngineBridge\Diagnostics\UnityDebugSink.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\InspectableReactiveProperty.cs">
+      <Link>UnityEngineBridge\InspectableReactiveProperty.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\InspectorDisplayDrawer.cs">
+      <Link>UnityEngineBridge\InspectorDisplayDrawer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\LazyTask.cs">
+      <Link>UnityEngineBridge\LazyTask.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\LifetimeDisposableExtensions.cs">
+      <Link>UnityEngineBridge\LifetimeDisposableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\MainThreadDispatcher.cs">
+      <Link>UnityEngineBridge\MainThreadDispatcher.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\MainThreadScheduler.cs">
+      <Link>UnityEngineBridge\MainThreadScheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Observable.Unity.cs">
+      <Link>UnityEngineBridge\Observable.Unity.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ObservableMonoBehaviour.cs">
+      <Link>UnityEngineBridge\ObservableMonoBehaviour.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ObservableWWW.cs">
+      <Link>UnityEngineBridge\ObservableWWW.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ObserveExtensions.cs">
+      <Link>UnityEngineBridge\ObserveExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\PresenterBase.cs">
+      <Link>UnityEngineBridge\PresenterBase.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ReactiveCollection.cs">
+      <Link>UnityEngineBridge\ReactiveCollection.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ReactiveDictionary.cs">
+      <Link>UnityEngineBridge\ReactiveDictionary.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ReactiveProperty.cs">
+      <Link>UnityEngineBridge\ReactiveProperty.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\ScenePlaybackDetector.cs">
+      <Link>UnityEngineBridge\ScenePlaybackDetector.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableAnimatorTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableAnimatorTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableCanvasGroupChangedTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableCanvasGroupChangedTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableCollision2DTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableCollision2DTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableCollisionTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableCollisionTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableDestroyTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableDestroyTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableEnableTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableEnableTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableEventTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableEventTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableFixedUpdateTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableFixedUpdateTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableLateUpdateTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableLateUpdateTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableMouseTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableMouseTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableRectTransformTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableRectTransformTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableStateMachineTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableStateMachineTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTransformChangedTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTransformChangedTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTrigger2DTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTrigger2DTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTriggerBase.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTriggerBase.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTriggerExtensions.Component.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTriggerExtensions.Component.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTriggerExtensions.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTriggerExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableTriggerTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableTriggerTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableUpdateTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableUpdateTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\Triggers\ObservableVisibleTrigger.cs">
+      <Link>UnityEngineBridge\Triggers\ObservableVisibleTrigger.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\TypedMonoBehaviour.cs">
+      <Link>UnityEngineBridge\TypedMonoBehaviour.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\UnityEventExtensions.cs">
+      <Link>UnityEngineBridge\UnityEventExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\UnityGraphicExtensions.cs">
+      <Link>UnityEngineBridge\UnityGraphicExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\UnityUIComponentExtensions.cs">
+      <Link>UnityEngineBridge\UnityUIComponentExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityWinRTBridge\Thread.cs">
+      <Link>UnityWinRTBridge\Thread.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityWinRTBridge\ThreadPoolScheduler_UnityWinRT.cs">
+      <Link>UnityWinRTBridge\ThreadPoolScheduler_UnityWinRT.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\UniRx.Library\UniRx.Library.csproj">
+      <Project>{21c57e17-d4b8-4da4-a6a2-07d8b2e5b3bd}</Project>
+      <Name>UniRx.Library</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Dlls/UniRx.Library/Properties/AssemblyInfo.cs
+++ b/Dlls/UniRx.Library/Properties/AssemblyInfo.cs
@@ -1,0 +1,33 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("UniRx.Library")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("UniRx.Library")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/Dlls/UniRx.Library/UniRx.Library.csproj
+++ b/Dlls/UniRx.Library/UniRx.Library.csproj
@@ -1,0 +1,224 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>UniRx</RootNamespace>
+    <AssemblyName>UniRx</AssemblyName>
+    <TargetFrameworkVersion>v3.5</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>TRACE;DEBUG;UniRxLibrary</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Asynchronous\WebRequestExtensions.cs">
+      <Link>Asynchronous\WebRequestExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\BooleanDisposable.cs">
+      <Link>Disposables\BooleanDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\CompositeDisposable.cs">
+      <Link>Disposables\CompositeDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\Disposable.cs">
+      <Link>Disposables\Disposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\DisposableExtensions.cs">
+      <Link>Disposables\DisposableExtensions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\ICancelable.cs">
+      <Link>Disposables\ICancelable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\MultipleAssignmentDisposable.cs">
+      <Link>Disposables\MultipleAssignmentDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\RefCountDisposable.cs">
+      <Link>Disposables\RefCountDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\ScheduledDisposable.cs">
+      <Link>Disposables\ScheduledDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\SerialDisposable.cs">
+      <Link>Disposables\SerialDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Disposables\SingleAssignmentDisposable.cs">
+      <Link>Disposables\SingleAssignmentDisposable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\EventPattern.cs">
+      <Link>EventPattern.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\ImmutableList.cs">
+      <Link>InternalUtil\ImmutableList.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\ListObserver.cs">
+      <Link>InternalUtil\ListObserver.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\PriorityQueue.cs">
+      <Link>InternalUtil\PriorityQueue.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\ReflectionAccessor.cs">
+      <Link>InternalUtil\ReflectionAccessor.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\ScheduledItem.cs">
+      <Link>InternalUtil\ScheduledItem.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\InternalUtil\ThreadSafeQueueWorker.cs">
+      <Link>InternalUtil\ThreadSafeQueueWorker.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Notification.cs">
+      <Link>Notification.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Notifiers\BooleanNotifier.cs">
+      <Link>Notifiers\BooleanNotifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Notifiers\CountNotifier.cs">
+      <Link>Notifiers\CountNotifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Notifiers\MessageBroker.cs">
+      <Link>Notifiers\MessageBroker.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Notifiers\ScheduledNotifier.cs">
+      <Link>Notifiers\ScheduledNotifier.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Aggregate.cs">
+      <Link>Observable.Aggregate.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Binding.cs">
+      <Link>Observable.Binding.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Blocking.cs">
+      <Link>Observable.Blocking.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Concatenate.cs">
+      <Link>Observable.Concatenate.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Concurrency.cs">
+      <Link>Observable.Concurrency.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Conversions.cs">
+      <Link>Observable.Conversions.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Creation.cs">
+      <Link>Observable.Creation.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.cs">
+      <Link>Observable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.ErrorHandling.cs">
+      <Link>Observable.ErrorHandling.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Events.cs">
+      <Link>Observable.Events.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.FromAsync.cs">
+      <Link>Observable.FromAsync.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Joins.cs">
+      <Link>Observable.Joins.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Paging.cs">
+      <Link>Observable.Paging.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observable.Time.cs">
+      <Link>Observable.Time.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Observer.cs">
+      <Link>Observer.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Schedulers\CurrentThreadScheduler.cs">
+      <Link>Schedulers\CurrentThreadScheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Schedulers\ImmediateScheduler.cs">
+      <Link>Schedulers\ImmediateScheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Schedulers\IScheduler.cs">
+      <Link>Schedulers\IScheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Schedulers\Scheduler.cs">
+      <Link>Schedulers\Scheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Schedulers\ThreadPoolScheduler.cs">
+      <Link>Schedulers\ThreadPoolScheduler.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\AsyncSubject.cs">
+      <Link>Subjects\AsyncSubject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\BehaviorSubject.cs">
+      <Link>Subjects\BehaviorSubject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\ConnectableObservable.cs">
+      <Link>Subjects\ConnectableObservable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\ISubject.cs">
+      <Link>Subjects\ISubject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\ReplaySubject.cs">
+      <Link>Subjects\ReplaySubject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Subjects\Subject.cs">
+      <Link>Subjects\Subject.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\System\IObservable.cs">
+      <Link>System\IObservable.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\System\IObserver.cs">
+      <Link>System\IObserver.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\System\IProgress.cs">
+      <Link>System\IProgress.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\System\Tuple.cs">
+      <Link>System\Tuple.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\System\Unit.cs">
+      <Link>System\Unit.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\TimeInterval.cs">
+      <Link>TimeInterval.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\Timestamped.cs">
+      <Link>Timestamped.cs</Link>
+    </Compile>
+    <Compile Include="..\..\Assets\UniRx\Scripts\UnityEngineBridge\AotSafeExtensions.cs">
+      <Link>UnityEngineBridge\AotSafeExtensions.cs</Link>
+    </Compile>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/UnityVS.UniRx.sln
+++ b/UnityVS.UniRx.sln
@@ -13,6 +13,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniRxAnalyzer.Test", "Analy
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniRxAnalyzer.Vsix", "Analyzer\UniRxAnalyzer\UniRxAnalyzer.Vsix\UniRxAnalyzer.Vsix.csproj", "{65D45FBA-A76A-4645-BF10-75D3A3D756C9}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniRx.Library", "Dlls\UniRx.Library\UniRx.Library.csproj", "{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UniRx.Library.Unity", "Dlls\UniRx.Library.Unity\UniRx.Library.Unity.csproj", "{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,6 +47,14 @@ Global
 		{65D45FBA-A76A-4645-BF10-75D3A3D756C9}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{65D45FBA-A76A-4645-BF10-75D3A3D756C9}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{65D45FBA-A76A-4645-BF10-75D3A3D756C9}.Release|Any CPU.Build.0 = Release|Any CPU
+		{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{21C57E17-D4B8-4DA4-A6A2-07D8B2E5B3BD}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0039CA1D-87A6-4F2F-85DC-659FFE5B56FB}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
This fixes for using UniRx with ViewModels project that does not depend UnityEngine.

I separate Scheduler and Observable for two added project.
UniRx.Library project is independent of UnityEngine.
UniRx.Library.Unity project is dependent on UnityEngine.
