### PR TITLE
Unity workaround リネーム漏れの修正、nuget 1.1.0

### DIFF
--- a/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround.csproj
+++ b/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net35;net46</TargetFrameworks>
+    <TargetFrameworks>net35;net46;netstandard1.3</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround.csproj
+++ b/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround.csproj
@@ -15,6 +15,7 @@
     <PackageProjectUrl>https://github.com/OrangeCube/UniRx</PackageProjectUrl>
     <Company>OrangeCube</Company>
     <Authors>OrangeCube</Authors>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UnityWorkaround.cs
+++ b/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UnityWorkaround.cs
@@ -5,8 +5,11 @@ using UniRx.SystemReactive.UnityWorkaround;
 namespace System.Reactive.Linq
 {
     /// <summary>
-    /// 本家System.ReactiveにあるMergeだとエラーが発生してしまうため    /// 独自実装したMergeへ明示的にフォワードさせる拡張メソッド
+    /// Unityで起こる問題を回避するためのクラス。
     /// </summary>
+    /// <remarks>
+    /// 現状本家RxのMergeがIL2CPPでは動かないため、Mergeだけ自作＆Mergeを使ってたら自作の方に置き換えるアナライザ－作成している
+    /// </remarks>
     public static class UnityWorkaround
     {
         /// <summary>

--- a/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UnityWorkaround.cs
+++ b/Dlls/UniRx.SystemReactive.UnityWorkaround/UniRx.SystemReactive.UnityWorkaround/UnityWorkaround.cs
@@ -5,10 +5,9 @@ using UniRx.SystemReactive.UnityWorkaround;
 namespace System.Reactive.Linq
 {
     /// <summary>
-    /// 本家System.ReactiveにあるMergeだとエラーが発生してしまうため
-    /// 独自実装したMergeへ明示的にフォワードさせる拡張メソッド
+    /// 本家System.ReactiveにあるMergeだとエラーが発生してしまうため    /// 独自実装したMergeへ明示的にフォワードさせる拡張メソッド
     /// </summary>
-    public static class ObservableForwardingToMerge
+    public static class UnityWorkaround
     {
         /// <summary>
         /// UniRxにあるScheduler.DefaultSchedulers.ConstantTimeOperations相当の処理

--- a/Dlls/UniRx.SystemReactive.UnityWorkaround/readme.md
+++ b/Dlls/UniRx.SystemReactive.UnityWorkaround/readme.md
@@ -1,0 +1,8 @@
+# Unity Workaround
+
+ Unity Workaround とは、Unityを利用することで起こる問題回避のもの。
+
+ - 本家RxのMergeがUnity IL2CPPで動かない。
+ - しょうがないからMergeだけ自作＆Mergeを使ってたら自作のほうに書き換えるアナライザーを作成
+ - 問題回避のためのやっつけてきなもので、Unityのバグが治ったらいらなくなるもの<br>
+  → なので名前も Unity Workaround(回避策)


### PR DESCRIPTION
クラス名のリネームが漏れてたのでその修正。