### PR TITLE
UniRx.SystemReactive.Unity csprojから、構成ProductionXXX を削除。

### DIFF
--- a/Dlls/UniRx.SystemReactive.Unity/UniRx.SystemReactive.Unity.csproj
+++ b/Dlls/UniRx.SystemReactive.Unity/UniRx.SystemReactive.Unity.csproj
@@ -2,29 +2,15 @@
   <PropertyGroup>
     <TargetFrameworks>net35;net46;netstandard2.0</TargetFrameworks>
     <DebugType Condition="'$(Configuration)'=='DEBUG'">full</DebugType>
-    <Configurations>Debug;Release;ProductionDebug;ProductionRelease;NoOpt</Configurations>
+    <Configurations>$(Configurations);NoOpt</Configurations>
   </PropertyGroup>
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{06D44A7D-5FF2-4CE0-9FB8-B0EE23A9F46C}</ProjectGuid>
-  </PropertyGroup>
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;UniRxLibrary SystemReactive</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE;UniRxLibrary SystemReactive</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+
+  <PropertyGroup>
+    <DefineConstants>$(DefineConstants);UniRxLibrary SystemReactive</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
構成をProductionDebug, Releaseにするとビルドが通ってなかった。
近々消える予定のプロジェクトでもあるので、ProductionXXX の構成を削除することにした。

他のプロジェクトは ProductionDebug, Releaseに設定してあっても標準の Debug, Release の構成を参照していたので問題になっていなかった。
